### PR TITLE
Use ykman via PATH and also mention that it is a required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # YubiKey
+
+Be sure to install [ykman](https://developers.yubico.com/yubikey-manager/) on your system, otherwise this extension will not work.

--- a/src/listAccounts.ts
+++ b/src/listAccounts.ts
@@ -20,7 +20,7 @@ function execute(command: string): Promise<string> {
 }
 
 export async function listAccounts(): Promise<Account[]> {
-  const result = await executeRetrying(() => execute("/usr/local/bin/ykman oath accounts code"), { retries: 5 });
+  const result = await executeRetrying(() => execute("$(which ykman) oath accounts code"), { retries: 5 });
   const lines = result.split("\n");
   return lines
     .filter((it) => !!it)


### PR DESCRIPTION
When installing ykman via brew, for example, it is not found in `/usr/local/bin`. This PR instead relies on whatever is available in the PATH and also mentions the dependency outright in the README.